### PR TITLE
PathQuery Generation - Final GSoC Pull Request

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ InterMine databases are queried using a GraphQL-like query language called PathQ
 
 For further information, refer to my (first) [article](https://medium.com/@jakemacneal/intermine-nlp-nlp-query-answering-for-intermine-e8dfdfb64b9) on medium.
 
+I (Jake) had the opportunity to work on this project as a recipient of a Google Summer of Code (2018) stipend.
+Coming soon: recap article for my Google Summer of Code, along with a small live demo.
+
 
 ## Current Status
 Most of the work to date has been at the parser level and below, developing a solid technical base

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # intermine-nlp
-Welcome to the intermine-nlp wiki!
+Welcome to intermine-nlp!
 
 intermine-nlp is a library for generating InterMine PathQuery queries (JSON or XML) from natural language queries. There are many queries which are difficult or impossible to word in English, let alone translate into a PathQuery. For this project, it’s only worth targeting relatively simple query structures which users of the natural language interface are likely to care about.
 

--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ to run all tests in the current test namespace.
 
 
 ## Future Work
-Ranked in ascending order of difficulty
+Ranked in ascending order of difficulty (and by urgency in descending order, approximately):
 
+* Improve test coverage of existing codebase
 * Parse sorting ("..., sort by length ascending.")
 * Multi-word fuzzy matching of raw input, such as "primary IDs"->"primaryIdentifier" (consider clojure.math.combinatorics)
 * Further improvement of grammar (resources/grammar.bnf) and query/parse functionality, manually covering more constructions and schema-dependant special cases

--- a/project.clj
+++ b/project.clj
@@ -23,9 +23,9 @@
                  [instaparse "1.4.9"]
                  [rhizome "0.2.9"]
                  [clj-fuzzy "0.4.1"]
+                 [org.clojure/math.combinatorics "0.1.4"]
                  ]
-  ;; :main ^:skip-aot intermine-nlp.core
   :main intermine-nlp.core
-  ;; :main ^:skip-aot intermine-nlp.nlp
+  ;; :main ^:skip-aot intermine-nlp.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject intermine-nlp "0.1.0-SNAPSHOT"
+(defproject intermine-nlp "0.1.1-SNAPSHOT"
   :description "intermine-nlp provides translation from natural (English) language to PathQuery queries."
   :url "http://example.com/FIXME"
   :license {:name "Gnu Lesser General Public License Version 2.1"

--- a/resources/grammar.bnf
+++ b/resources/grammar.bnf
@@ -20,6 +20,7 @@ QUERY =
   | 'show' QUERY
   | 'show me' QUERY
   | 'show I' QUERY
+  | 'show i' QUERY
   | 'show all' QUERY
   | 'show the' QUERY
   | 'which' QUERY
@@ -31,6 +32,7 @@ QUERY =
   | 'list all' QUERY
   | 'what is' QUERY
   | 'I want to see' QUERY
+  | 'i want to see' QUERY
   | "the" QUERY
   | QUERY 'in' ORGANISM
   | ORGANISM QUERY
@@ -54,6 +56,7 @@ PATH =
   | FIELD
   | FIELD 'of' CLASS
   | CLASS 'with' FIELD
+  | (CLASS '.')+ FIELD
 
 
 CONSTRS =

--- a/resources/grammar.bnf
+++ b/resources/grammar.bnf
@@ -1,14 +1,20 @@
 QUERY =
   VIEW
-  | VIEW 'where' CONSTR
-  | VIEW 'with' CONSTR
-  | VIEW 'in which' CONSTR
-  | VIEW 'for which' CONSTR
-  | VIEW 'have' CONSTR
-  | VIEW 'are' CONSTR
-  | VIEW 'is' CONSTR
-  | VIEW 'have' CONSTR
-  | VIEW CONSTR
+  | VIEW 'where' CONSTRS
+  | VIEW 'with' CONSTRS
+  | VIEW 'in which' CONSTRS
+  | VIEW 'for which' CONSTRS
+  | VIEW 'have' CONSTRS
+  | VIEW 'are' CONSTRS
+  | VIEW 'is' CONSTRS
+  | VIEW 'have' CONSTRS
+  | VIEW CONSTRS
+  | ORGANISM ',' VIEW
+  | ORGANISM ',' VIEW CONSTRS
+  | ORGANISM 'show the' VIEW
+  | ORGANISM 'show the' VIEW CONSTRS
+  | VIEW 'in' ORGANISM
+  | VIEW CONSTRS 'in' ORGANISM
   | 'show' QUERY
   | 'show me' QUERY
   | 'show I' QUERY
@@ -23,38 +29,42 @@ QUERY =
   | 'list all' QUERY
   | 'what is' QUERY
   | 'I want to see' QUERY
+  | "the" QUERY
+  | QUERY 'in' ORGANISM
+  | ORGANISM QUERY
   | QUERY 'sort' SORT
   | QUERY 'sort by' SORT
   | QUERY "?"
   | QUERY "."
   | QUERY "!"
 
+
 VIEW =
-  VIEW 'and' VIEW
-  | CLASS
+  PATH ('and' PATH)+
+  | PATH (',' PATH)+
+  | PATH
+
+PATH =
+  CLASS
   | CLASS FIELD
   | FIELD
-  | ORGANISM
-  | ORGANISM ',' CLASS
-  | ORGANISM ',' CLASS FIELD
-  | ORGANISM 'show the' CLASS
-  | ORGANISM 'show the' FIELD
-  | ORGANISM 'show the' CLASS FIELD
 
+CONSTRS =
+  CONSTR ('and' CONSTR)+
+  | CONSTR ('or' CONSTR)+
+  | CONSTR (',' CONSTR)+
+  | CONSTR
 
 CONSTR =
-  CONSTR 'and' CONSTR
-  | CONSTR 'or' CONSTR
-  | VALUE
-  | CLASS 'exists'
-  | FIELD COMPARE VALUE
-  | VALUE COMPARE FIELD
-  | FIELD VALUE
-  | VALUE FIELD
-  | FIELD MULTI_COMPARE VALUES
-  | VALUES MULTI_COMPARE FIELD
-  | UNARY_OP FIELD
-  | FIELD UNARY_OP
+  VALUE
+  | PATH 'exists'
+  | PATH COMPARE VALUE
+  | PATH VALUE
+  | VALUE PATH
+  | PATH MULTI_COMPARE VALUES
+  | VALUES MULTI_COMPARE PATH
+  | UNARY_OP PATH
+  | PATH UNARY_OP
 
 
 COMPARE =
@@ -150,6 +160,7 @@ MULTI_COMPARE =
 
 M_ONE_OF =
   "one of"
+  | "one of either"
   | "contained in"
   | "in"
   | "either"
@@ -199,10 +210,13 @@ SORT =
   | VALUE 'ascend'
 
 VALUES =
-  VALUE VALUE+
+  VALUE (("or"|"and"|",") VALUE)+
+
 
 VALUE =
   #"[0-9a-zA-Z]+"
 
 ORGANISM =
-  'Fly'
+  'fly'
+  | 'drosophila'
+  | 'Drosophila'

--- a/resources/grammar.bnf
+++ b/resources/grammar.bnf
@@ -34,6 +34,8 @@ QUERY =
   | "the" QUERY
   | QUERY 'in' ORGANISM
   | ORGANISM QUERY
+  | 'from' ORGANISM 'select' QUERY
+  | 'from' ORGANISM QUERY
   | QUERY 'sort' SORT
   | QUERY 'sort by' SORT
   | QUERY "?"

--- a/resources/grammar.bnf
+++ b/resources/grammar.bnf
@@ -7,6 +7,7 @@ QUERY =
   | VIEW 'have' CONSTRS
   | VIEW 'are' CONSTRS
   | VIEW 'is' CONSTRS
+  | VIEW 'be' CONSTRS
   | VIEW 'have' CONSTRS
   | VIEW CONSTRS
   | ORGANISM ',' VIEW
@@ -97,6 +98,7 @@ LIKE =
 NLIKE =
   "not" LIKE
   | "isn't" LIKE
+  | "be not" LIKE
 
 MATH_COMP =
   EQ
@@ -154,7 +156,6 @@ LEQ =
   LT 'or' EQ
   | '<='
 
-
 LIST_COMP =
   "%NOT IMPLEMENTED"
 
@@ -178,6 +179,7 @@ M_ONE_OF =
 M_NONE_OF =
   "not" M_ONE_OF
   | "isn't" M_ONE_OF
+  | "be not" M_ONE_OF
   | "neither"
 
 M_OVERLAPS =
@@ -187,6 +189,7 @@ M_OVERLAPS =
 M_NOVERLAPS =
   "not" M_OVERLAPS
   | "isn't" M_OVERLAPS
+  | "be not" M_OVERLAPS
 
 M_OUTSIDE =
   "%NOT IMPLEMENTED"
@@ -209,10 +212,10 @@ NULL =
   | "empty"
 
 NNULL =
-  "not null"
-  | "isn't null"
-  | "not empty"
-  | "isn't empty"
+  "not" NULL
+  | "isn't" NULL
+  | "be not" NULL
+  | "is not" NULL
 
 SORT =
   SORT SORT

--- a/resources/grammar.bnf
+++ b/resources/grammar.bnf
@@ -15,6 +15,7 @@ QUERY =
   | ORGANISM 'show the' VIEW CONSTRS
   | VIEW 'in' ORGANISM
   | VIEW CONSTRS 'in' ORGANISM
+  | 'the' QUERY
   | 'show' QUERY
   | 'show me' QUERY
   | 'show I' QUERY
@@ -48,6 +49,9 @@ PATH =
   CLASS
   | CLASS FIELD
   | FIELD
+  | FIELD 'of' CLASS
+  | CLASS 'with' FIELD
+
 
 CONSTRS =
   CONSTR ('and' CONSTR)+
@@ -124,7 +128,11 @@ GT =
   | 'greater than'
   | 'over'
   | 'more than'
+  | 'above'
+  | 'longer'
+  | 'longer than'
   | '>'
+
 
 LT =
   'LT'
@@ -134,6 +142,8 @@ LT =
   | 'less than'
   | 'below'
   | 'under'
+  | 'shorter'
+  | 'shorter than'
   | '<'
 
 GEQ =

--- a/resources/grammar.bnf
+++ b/resources/grammar.bnf
@@ -223,7 +223,7 @@ NNULL =
   | "is not" NULL
 
 SORT =
-  SORT SORT
+  SORT SORT+
   | VALUE 'descend'
   | VALUE 'ascend'
 

--- a/src/intermine_nlp/README.md
+++ b/src/intermine_nlp/README.md
@@ -3,12 +3,24 @@ Core project namespace. Contains top-level parser pipeline functions (parser-pip
 
 Key functions: `parser-pipeline`, `-main`
 
+
 # parse.clj
 Functions for generating parses, based on the combination of a grammar file (resources/grammar.bnf)
 and a model-specific set of productions generated on-the-fly. Also, transformation functions of
 produced parse trees to facilitate full query translation.
 
 Key function: `gen-parser`
+
+
+# query.clj
+Functions which operated on a transformed parse tree (a map of :VIEW, :CONSTRS, and
+:ORGANISM keys) to produce legal PathQuery query maps, which may be used by imcljs
+to query a database, or for direct conversion into xml. Does simple replacements
+on the input tree (reverse-lemma mapping back onto the database class/feature schema,
+and replacing internal operation keywords with their schema equivalents).
+
+Key function: `gen-query`
+
 
 # nlp.clj
 NLP toolbox: an interface to tools from the OpenNLP and Stanford CoreNLP projects. Currently
@@ -17,11 +29,28 @@ may come into use soon for handling difficult queries.
 
 Key functions: `lemmatize-as-text`, `lemma-map`, `tokenize`
 
+
+# fuzzy.clj
+Fuzzy string toolbox: functions to find and replace strings or substrings within strings
+with their closest matches from within a reference dictionary. This 'dictionary' is generally
+a seq of class and/or field names. The main purpose is to be used before the parsing stage,
+allowing the raw input string to be scanned for near-matches (i.e., 'primary id' ~= 'primaryIdentifier').
+
+Key functions: `replace-field-names`, `replace-class-names`
+
+
 # model.clj
 For fetching model data from a remote intermine database, as well as for loading and storing said
 data locally.
 
 Key function: `fetch-model`
+
+
+# util.clj
+Contains helper functions, mostly for fetching data from an intermine remote database.
+
+Key functions: `possible-values`, `summaries`
+
 
 # randquery.clj
 For generating random PathQuery queries, used internally in order to automate the collection of
@@ -45,10 +74,6 @@ Example:
       (pprint query2))
 ```
 
-# util.clj
-Contains helper functions, mostly for fetching data from an intermine remote database.
-
-Key functions: `possible-values`, `summaries`
 
 # template.clj
 For fetching template data from a remote intermine database, plus loading and storing (same as model.clj).

--- a/src/intermine_nlp/core.clj
+++ b/src/intermine_nlp/core.clj
@@ -5,39 +5,46 @@
             [intermine-nlp.util :as util]
             [instaparse.core :as insta]
             [clojure.string :as string]
-            [clojure.pprint :refer [pprint]])
+            [clojure.pprint :refer [pprint]]
+            [clojure.set :refer [map-invert]])
   (:gen-class))
 
+(defn gen-view
+  "Merge the values in a map of view elements (:CLASS, :FIELD) into an
+  imcljs view map."
+  [view lemma-class-map lemma-field-map]
+  (let [class (get lemma-class-map (:CLASS view))
+        field (get lemma-field-map (:FIELD view))]
+    (if class
+      (str class "." field)
+      field)))
 
-(defn read-sentence
-  "Read a sentence from a file (for testing)"
-  [path]
-  (-> path slurp read-string :english))
+(defn gen-constraint
+  "Merge the values in a map of constraint elements(:CLASS, :FIELD, :VALUE,
+  :COMPARE, :MULTI_COMPARE, :UNARY_OP) into an imcljs constraint map."
+  [constraints lemma-class-map lemma-field-map])
 
-(defn read-pathquery
-  "Read a PathQuery from a file (for testing)"
-  [path]
-  (-> path slurp read-string :pathquery))
+(defn gen-query
+  "Generate a query from a map containing :VIEW :CONSTRS and :ORGANISM keys."
+  [model query-map]
+  (let [lemma-class-map (map-invert (parse/class-lemma-mapping model))
+        lemma-field-map (map-invert (parse/field-lemma-mapping model))
+        views (flatten (map vals (:VIEW query-map)))
+        constraints (flatten (map vals (:CONSTRS query-map)))]
+    {:select (map #(gen-view % lemma-class-map lemma-field-map) views)
+     :where (map #(gen-constraint % lemma-class-map lemma-field-map) constraints)}))
 
 
 (defn parser-pipeline
   "Generate a parser pipeline for a given InterMine model.
   options:
-         :lemmatize (default = false)"
+  "
   [model & {:as options}]
-  (let [class-lemma-map (->> model
-                             :classes
-                             keys
-                             (map name)
-                             (clojure.string/join " ")
-                             nlp/lemma-map)
-        parser (parse/gen-parser model)
-        parser-lemmatized (parse/gen-parser model class-lemma-map)]
-    #(cond->> %
-        (:lemmatize options) nlp/lemmatize-as-text
-        (:lemmatize options) parser-lemmatized
-        (not (:lemmatize options)) parser
-        ;; (:lemmatize options) transform tree
+  (let [parser (parse/gen-parser model)]
+    #(->> %
+          nlp/lemmatize-as-text
+          parser
+          ;; parse/transform-tree
         )))
 
 (defn -main

--- a/src/intermine_nlp/core.clj
+++ b/src/intermine_nlp/core.clj
@@ -34,7 +34,8 @@
   "I'll try to parse your English query and give you the PathQuery translation."
   [& args]
   (let [fly-model (model/fetch-model "fly")
-        pipeline (parser-pipeline fly-model)]
+        fly-service {:root "www.flymine.org/query" :model fly-model}
+        pipeline (parser-pipeline fly-service)]
     (pprint "Enter a simple query and I'll attempt to parse it!")
     (pprint "Example: Show me genes with primaryIdentifier like ovo.")
     (loop []

--- a/src/intermine_nlp/core.clj
+++ b/src/intermine_nlp/core.clj
@@ -15,14 +15,15 @@
   "Generate a parser pipeline for a given InterMine model.
   options:
   "
-  [model & {:as options}]
-  (let [parser (parse/gen-parser model)]
+  [service & {:as options}]
+  (let [model (:model service)
+        parser (parse/gen-parser model)]
     #(->> %
           nlp/lemmatize-as-text
           parser
           parse/transform-tree
-          (query/gen-query model)
-        )))
+          (query/gen-query service)
+          )))
 
 (defn -main
   "In the future I'll return a query, right now I'll just give you the parse tree."

--- a/src/intermine_nlp/core.clj
+++ b/src/intermine_nlp/core.clj
@@ -6,34 +6,10 @@
             [instaparse.core :as insta]
             [clojure.string :as string]
             [clojure.pprint :refer [pprint]]
-            [clojure.set :refer [map-invert]])
+            [clojure.set :refer [map-invert]]
+            [imcljs.query :as im-query]
+            [intermine-nlp.query :as query])
   (:gen-class))
-
-(defn gen-view
-  "Merge the values in a map of view elements (:CLASS, :FIELD) into an
-  imcljs view map."
-  [view lemma-class-map lemma-field-map]
-  (let [class (get lemma-class-map (:CLASS view))
-        field (get lemma-field-map (:FIELD view))]
-    (if class
-      (str class "." field)
-      field)))
-
-(defn gen-constraint
-  "Merge the values in a map of constraint elements(:CLASS, :FIELD, :VALUE,
-  :COMPARE, :MULTI_COMPARE, :UNARY_OP) into an imcljs constraint map."
-  [constraints lemma-class-map lemma-field-map])
-
-(defn gen-query
-  "Generate a query from a map containing :VIEW :CONSTRS and :ORGANISM keys."
-  [model query-map]
-  (let [lemma-class-map (map-invert (parse/class-lemma-mapping model))
-        lemma-field-map (map-invert (parse/field-lemma-mapping model))
-        views (flatten (map vals (:VIEW query-map)))
-        constraints (flatten (map vals (:CONSTRS query-map)))]
-    {:select (map #(gen-view % lemma-class-map lemma-field-map) views)
-     :where (map #(gen-constraint % lemma-class-map lemma-field-map) constraints)}))
-
 
 (defn parser-pipeline
   "Generate a parser pipeline for a given InterMine model.
@@ -44,7 +20,8 @@
     #(->> %
           nlp/lemmatize-as-text
           parser
-          ;; parse/transform-tree
+          parse/transform-tree
+          (query/gen-query model)
         )))
 
 (defn -main

--- a/src/intermine_nlp/fuzzy.clj
+++ b/src/intermine_nlp/fuzzy.clj
@@ -1,0 +1,51 @@
+(ns intermine-nlp.fuzzy
+  (:require [clojure.pprint :refer [pprint]]
+            [clj-fuzzy.metrics :as fuzzy]
+            [clojure.string :as string]
+            [intermine-nlp.util :as util]
+            [clojure.math.combinatorics :as comb])
+  (:gen-class))
+
+
+(defn best-match
+    "For a given string and dictionary, return a tuple of [word, score] representing
+  the highest-scored match.
+  Example: (best-match 'Manager' ['martian' 'manatee' 'bison'])
+         -> ['manatee' 0.5]
+  "
+  ([text dictionary]
+   (let [match (apply max-key #(fuzzy/sorensen text %) dictionary)]
+     [match (fuzzy/sorensen text match)])))
+
+(defn best-match-pred
+  "Returns a function which returns best-match word if score is over threshold,
+  otherwise returns original string.
+  Example: (filter (best-match-pred ['apple' 'banana'] 0.5) ['applause'])
+         -> 'apple'
+           (filter (best-match-pred ['apple' 'banana'] 0.7) ['applause'])
+         -> 'applause'"
+  [dictionary threshold]
+  #(let [[match score] (best-match % dictionary)]
+     (if (>= score threshold)
+       match
+       %)))
+
+(defn replace-fuzzy
+  "Replace all words in a string which match with minimum threshold certainty (0.0-1.0)
+  to their matching partner in a list.
+  Example: (replace-fuzzy 'These are amazing words' ['amaze' 'wards'] 0.5)
+         -> 'These are amaze wards"
+  [text dictionary threshold]
+  (let [split-string (split text #" ")
+        match-pred (best-match-pred dictionary threshold)]
+    (string/join " " (map match-pred split-string))))
+
+(defn replace-class-names
+  [text model threshold]
+  (let [class-names (util/class-names model)]
+    (replace-fuzzy text class-names threshold)))
+
+(defn replace-field-names
+  [text model threshold]
+  (let [field-names (util/field-names model)]
+    (replace-fuzzy text field-names threshold)))

--- a/src/intermine_nlp/parse.clj
+++ b/src/intermine_nlp/parse.clj
@@ -6,7 +6,8 @@
             [clojure.pprint :refer [pprint]]
             [intermine-nlp.nlp :as nlp]
             [clojure.string :as string]
-            [clojure.java.io :as io])
+            [clojure.java.io :as io]
+            [intermine-nlp.util :as util])
   (:gen-class))
 
 (def grammar (-> "grammar.bnf" io/resource io/input-stream slurp))
@@ -16,9 +17,7 @@
   mapping lemmatized class names to un-lemmatized ones."
   [model]
   (->> model
-       :classes
-       keys
-       (map name)
+       util/class-names
        (clojure.string/join " ")
        nlp/lemma-map))
 
@@ -26,15 +25,10 @@
   "Given a model, lemmatizes all field names and returns a hash map,
   mapping lemmatized fields to un-lemmatized ones."
   [model]
-  (let [classes (:classes model)
-        class-kws (keys classes)
-        class-paths (map name class-kws)]
-    (apply merge (map #(->> %
-                            (im-path/attributes model)
-                            keys
-                            (map name)
-                            (clojure.string/join " ")
-                            nlp/lemma-map) class-paths))))
+  (let [field-paths (util/field-names model)]
+    (->> field-paths
+         (clojure.string/join " ")
+         nlp/lemma-map)))
 
 (defn model-grammar
   "Generate a grammar (parse map) for an intermine model.

--- a/src/intermine_nlp/parse.clj
+++ b/src/intermine_nlp/parse.clj
@@ -11,24 +11,38 @@
 
 (def grammar (-> "grammar.bnf" io/resource io/input-stream slurp))
 
+(defn class-lemma-mapping
+  "Given a model, lemmatizes all class names and returns a hash map,
+  mapping lemmatized class names to un-lemmatized ones."
+  [model]
+  (->> model
+       :classes
+       keys
+       (map name)
+       (clojure.string/join " ")
+       nlp/lemma-map))
+
+(defn field-lemma-mapping
+  "Given a model, lemmatizes all field names and returns a hash map,
+  mapping lemmatized fields to un-lemmatized ones."
+  [model]
+  (let [classes (:classes model)
+        class-kws (keys classes)
+        class-paths (map name class-kws)]
+    (apply merge (map #(->> %
+                            (im-path/attributes model)
+                            keys
+                            (map name)
+                            (clojure.string/join " ")
+                            nlp/lemma-map) class-paths))))
+
 (defn model-grammar
   "Generate a grammar (parse map) for an intermine model.
   Consists of 2 productions: one for classes, one for all fields/attributes.
   "
   ([model]
-   (let [classes (:classes model)
-         class-kws (keys classes)
-         class-paths (map name class-kws)
-         class-lemma-map (nlp/lemma-map (string/join " " class-paths))
-         attr-map (map #(hash-map :class % :attrs (im-path/attributes model %)) class-paths)
-         attr-keys (distinct (flatten (map #(->> % :attrs keys)  attr-map)))
-         attrs (map name attr-keys)]
-     (merge
-      {:FIELD (apply alt (map #(string %) attrs))}
-      {:CLASS (apply alt (map #(string %) class-paths))})))
-
-  ([model class-lemma-map]
-   (let [class-paths (keys class-lemma-map)
+   (let [class-lemma-map (class-lemma-mapping model)
+         class-paths (keys class-lemma-map)
          attr-map (map #(hash-map :class % :attrs (im-path/attributes model %)) class-paths)
          attr-keys (distinct (flatten (map #(->> % :attrs keys)  attr-map)))
          attrs (map (comp nlp/lemmatize-as-text name) attr-keys)]
@@ -47,37 +61,63 @@
                    :start :QUERY
                    :auto-whitespace :standard
                    :string-ci true)))
-  ([model class-lemma-map]
-   (let [top-grammar (ebnf grammar)
-         bottom-grammar (model-grammar model class-lemma-map)]
-     (insta/parser (merge top-grammar bottom-grammar)
-                   :start :QUERY
-                   :auto-whitespace :standard
-                   :string-ci true)))
-  ([model top-grammar class-lemma-map]
-   (let [bottom-grammar (model-grammar model class-lemma-map)]
+  ([model top-grammar]
+   (let [bottom-grammar (model-grammar model)]
      (insta/parser (merge top-grammar bottom-grammar)
                    :start :QUERY
                    :auto-whitespace :standard
                    :string-ci true))))
 
+
 ;;; Parse Tree transformations
 (def view-map
-  {:ORGANISM (fn [text] {:from text})
-   :CLASS (fn [text] {:select text})
-   :FIELD (fn [text] {:select text})})
+  {:PATH  (fn [& children] {:PATH (apply merge (remove string? children))})
+   :CLASS (fn [text] {:CLASS text})
+   :FIELD (fn [text] {:FIELD text})
+   :VALUE (fn [text] {:VALUE text})
+   })
+
+(defn transform-view
+  "Transform :VIEW map into a format recognizable by imcljs"
+  [view-tree]
+  (let [tree (insta/transform view-map view-tree)]
+    (->> tree
+         (remove string?)
+         flatten
+         (remove string?))))
 
 (def constraint-map
-  {:CLASS (fn [text] [:from text])
-   :FIELD (fn [text] [:select text])})
+  {:CONSTR (fn [& constr] {:CONSTR (apply merge constr)})
+   :PATH  (fn [& path] {:PATH (apply merge path)})
+   :CLASS (fn [text] {:CLASS text})
+   :FIELD (fn [text] {:FIELD text})
+   :VALUE (fn [text] {:VALUE text})
+   :VALUES (fn [& values] {:VALUES (filter identity (map :VALUE values))})
+   :COMPARE (fn [comparison] {:COMPARE (first (second comparison))})
+   :MULTI_COMPARE (fn [comparison] {:MULTI_COMPARE (first comparison)})
+   :UNARY_OP (fn [op] {:UNARY_OP (first op)})
+   })
 
-(def transform-map
+(defn transform-constraints
+  "Transform :CONSTR map into a format recognizable by imcljs"
+  [constr-tree]
+  (let [tree (insta/transform constraint-map constr-tree)]
+    (->> tree
+         flatten
+         (remove string?)
+         ;; (apply merge)
+         )))
+
+(def top-map
   {:QUERY (fn [& children] (remove string? children))
-  :VIEW (fn [& children] (insta/transform view-map children))
-   :CONSTR (fn [& children] [:CONSTR (remove string? children)])
-   :VALUE (fn [text] [:VALUE text])})
+   :ORGANISM (fn [text] {:ORGANISM text})
+   :VIEW (fn [& children] {:VIEW
+                             (transform-view (remove string? children))})
+   :CONSTRS (fn [& children] {:CONSTRS
+                             (transform-constraints (remove string? children))})
+})
 
 (defn transform-tree
   "Transform a parse tree according "
   [parse-tree]
-  (insta/transform transform-map parse-tree))
+  (apply merge (flatten (insta/transform top-map parse-tree))))

--- a/src/intermine_nlp/parse.clj
+++ b/src/intermine_nlp/parse.clj
@@ -7,7 +7,8 @@
             [intermine-nlp.nlp :as nlp]
             [clojure.string :as string]
             [clojure.java.io :as io]
-            [intermine-nlp.util :as util])
+            [intermine-nlp.util :as util]
+            [intermine-nlp.fuzzy :as fuzzy])
   (:gen-class))
 
 (def grammar (-> "grammar.bnf" io/resource io/input-stream slurp))
@@ -102,10 +103,12 @@
   {:QUERY (fn [& children] (remove string? children))
    :ORGANISM (fn [text] {:ORGANISM text})
    :VIEW (fn [& children] {:VIEW
-                             (transform-view (remove string? children))})
+                          (vec (transform-view (remove string? children)))})
    :CONSTRS (fn [& children] {:CONSTRS
-                             (transform-constraints (remove string? children))})
-})
+                             (vec (transform-constraints (remove string? children)))})
+   ;; :SORT (fn [& children] {:SORT
+   ;;                        (vec (transform-sort (remove string? children)))})
+   })
 
 (defn transform-tree
   "Transform a parse tree according "

--- a/src/intermine_nlp/parse.clj
+++ b/src/intermine_nlp/parse.clj
@@ -16,10 +16,10 @@
   "Given a model, lemmatizes all class names and returns a hash map,
   mapping lemmatized class names to un-lemmatized ones."
   [model]
-  (->> model
-       util/class-names
-       (clojure.string/join " ")
-       nlp/lemma-map))
+  (let [class-paths (util/class-names model)]
+    (->> class-paths
+         (clojure.string/join " ")
+         nlp/lemma-map)))
 
 (defn field-lemma-mapping
   "Given a model, lemmatizes all field names and returns a hash map,
@@ -49,12 +49,8 @@
   with a model-specific parser.
   "
   ([model]
-   (let [top-grammar (ebnf grammar)
-         bottom-grammar (model-grammar model)]
-     (insta/parser (merge top-grammar bottom-grammar)
-                   :start :QUERY
-                   :auto-whitespace :standard
-                   :string-ci true)))
+   (let [top-grammar (ebnf grammar)]
+     (gen-parser model top-grammar)))
   ([model top-grammar]
    (let [bottom-grammar (model-grammar model)]
      (insta/parser (merge top-grammar bottom-grammar)

--- a/src/intermine_nlp/query.clj
+++ b/src/intermine_nlp/query.clj
@@ -4,6 +4,26 @@
             [clojure.set :refer [map-invert]])
   (:gen-class))
 
+(def op-map {
+             :EQ "="
+             :NEQ "!="
+             :GT ">"
+             :LT "<"
+             :GEQ ">="
+             :LEQ "<="
+             :IN "IN"
+             :NIN "NOT IN"
+             :M_ONE_OF "ONE OF"
+             :M_NONE_OF "NONE OF"
+             :M_OVERLAPS "OVERLAPS"
+             :M_NOVERLAPS "DOES NOT OVERLAP"
+             :M_OUTSIDE "OUTSIDE"
+             :M_WITHIN "WITHIN"
+             :M_CONTAINS "CONTAINS"
+             :M_NCONTAINS "DOES NOT CONTAIN"
+             :NULL "IS NULL"
+             :NNULL "IS NOT NULL"})
+
 (defn gen-path
   "Merge the values in a map of view elements (:CLASS, :FIELD) into an
   imcljs view map."
@@ -20,9 +40,9 @@
   :COMPARE, :MULTI_COMPARE, :UNARY_OP) into an imcljs constraint map."
   [constraint lemma-class-map lemma-field-map]
   (let [path (gen-path (:PATH constraint) lemma-class-map lemma-field-map)
-        compare (:COMPARE constraint)
-        multi-compare (:MULTI_COMPARE constraint)
-        unary-op (:UNARY_OP constraint)
+        compare (get op-map (:COMPARE constraint))
+        multi-compare (get op-map (:MULTI_COMPARE constraint))
+        unary-op (get op-map (:UNARY_OP constraint))
         value (:VALUE constraint)
         values (:VALUES constraint)]
     (cond

--- a/src/intermine_nlp/query.clj
+++ b/src/intermine_nlp/query.clj
@@ -1,0 +1,50 @@
+(ns intermine-nlp.query
+  (:require [intermine-nlp.parse :as parse]
+            [clojure.pprint :refer [pprint]]
+            [clojure.set :refer [map-invert]])
+  (:gen-class))
+
+(defn gen-path
+  "Merge the values in a map of view elements (:CLASS, :FIELD) into an
+  imcljs view map."
+  [path lemma-class-map lemma-field-map]
+  (let [class (get lemma-class-map (:CLASS path))
+        field (get lemma-field-map (:FIELD path))]
+    (cond
+      (and (not-empty class) (not-empty field)) (str class "." field)
+      (not-empty class) class
+      (not-empty field) field)))
+
+(defn gen-constraint
+  "Merge the values in a map of constraint elements(:CLASS, :FIELD, :VALUE,
+  :COMPARE, :MULTI_COMPARE, :UNARY_OP) into an imcljs constraint map."
+  [constraint lemma-class-map lemma-field-map]
+  (let [path (gen-path (:PATH constraint) lemma-class-map lemma-field-map)
+        compare (:COMPARE constraint)
+        multi-compare (:MULTI_COMPARE constraint)
+        unary-op (:UNARY_OP constraint)
+        value (:VALUE constraint)
+        values (:VALUES constraint)]
+    (cond
+      compare {:path path
+               :op compare
+               :value value}
+      multi-compare {:path path
+                     :op compare
+                     :value values}
+      unary-op {:path path
+                :op unary-op}
+      :else    {:path path
+                :op "="
+                :value value}
+    )))
+
+(defn gen-query
+  "Generate a query from a map containing :VIEW :CONSTRS and :ORGANISM keys."
+  [model parse-map]
+  (let [lemma-class-map (map-invert (parse/class-lemma-mapping model))
+        lemma-field-map (map-invert (parse/field-lemma-mapping model))
+        view (:VIEW parse-map)
+        constraints (:CONSTRS parse-map)]
+    {:select (vec (map #(gen-path (:PATH %) lemma-class-map lemma-field-map) view))
+     :where (vec (map #(gen-constraint (:CONSTR %) lemma-class-map lemma-field-map) constraints))}))

--- a/src/intermine_nlp/randquery.clj
+++ b/src/intermine_nlp/randquery.clj
@@ -193,7 +193,7 @@
           path (im-path/join-path class-kws)
           top-path (im-path/adjust-path-to-last-class model path)
           top-path-kw (keyword top-path)
-          summary (top-path-kw (util/summaries service))]
+          summary (top-path-kw (util/fetch-summaries service))]
       (vec (map (partial merge-paths path) summary)))))
 
 (defn rand-class

--- a/src/intermine_nlp/randquery.clj
+++ b/src/intermine_nlp/randquery.clj
@@ -1,6 +1,5 @@
 (ns intermine-nlp.randquery
-  (:require [imcljs.query :as query]
-            [imcljs.path :as im-path]
+  (:require [imcljs.path :as im-path]
             [clojure.pprint :refer [pprint]]
             [clojure.string :as string]
             [intermine-nlp.util :as util]

--- a/src/intermine_nlp/util.clj
+++ b/src/intermine_nlp/util.clj
@@ -47,8 +47,16 @@
   of possible-values and unique-values are broken"
   (memoize possible-values-))
 
-(def summaries
+(def fetch-summaries
+  "Fetch summary fields for all classes in a database.
+  Argument: service"
   (memoize (partial im-fetch/summary-fields)))
+
+(defn class-summary
+  "Fetches the summary for a given class from a given db service"
+  [service class-name]
+  (let [summaries (fetch-summaries service)]
+    (get summaries (keyword class-name))))
 
 (defn class-names
   "Returns a list of class names (strings) for all classes in a given model."
@@ -56,7 +64,8 @@
   (->> model
        :classes
        keys
-       (map name)))
+       (map name)
+       distinct))
 
 (defn field-names
   "Returns a list of class names (strings) for all classes in a given model."

--- a/src/intermine_nlp/util.clj
+++ b/src/intermine_nlp/util.clj
@@ -49,3 +49,20 @@
 
 (def summaries
   (memoize (partial im-fetch/summary-fields)))
+
+(defn class-names
+  "Returns a list of class names (strings) for all classes in a given model."
+  [model]
+  (->> model
+       :classes
+       keys
+       (map name)))
+
+(defn field-names
+  "Returns a list of class names (strings) for all classes in a given model."
+  [model]
+  (let [class-paths (class-names model)]
+    (distinct (flatten (map #(->> %
+                                  (im-path/attributes model)
+                                  keys
+                                  (map name)) class-paths)))))

--- a/src/intermine_nlp/util.clj
+++ b/src/intermine_nlp/util.clj
@@ -68,10 +68,16 @@
        distinct))
 
 (defn field-names
-  "Returns a list of class names (strings) for all classes in a given model."
-  [model]
-  (let [class-paths (class-names model)]
-    (distinct (flatten (map #(->> %
-                                  (im-path/attributes model)
-                                  keys
-                                  (map name)) class-paths)))))
+  "Returns a list of field names (strings) for all classes in a given model.
+  If class provided, returns list of fields for given class in model."
+  ([model]
+   (let [class-paths (class-names model)]
+     (distinct (flatten (map #(->> %
+                                   (im-path/attributes model)
+                                   keys
+                                   (map name)) class-paths)))))
+  ([model class]
+   (distinct (flatten (->> class
+                           (im-path/attributes model)
+                           keys
+                           (map name))))))

--- a/src/intermine_nlp/util.clj
+++ b/src/intermine_nlp/util.clj
@@ -58,6 +58,12 @@
   (let [summaries (fetch-summaries service)]
     (get summaries (keyword class-name))))
 
+(defn un-lemmatize
+  "Convert a lemmatized  path back to its schema form. If no match (or if
+  the path is already in schema form), return the original path."
+  [path lemma-path-map]
+  (or (get lemma-path-map path) path))
+
 (defn class-names
   "Returns a list of class names (strings) for all classes in a given model."
   [model]

--- a/test/intermine_nlp/core_test.clj
+++ b/test/intermine_nlp/core_test.clj
@@ -1,17 +1,17 @@
 (ns intermine-nlp.core-test
   (:require [clojure.test :refer :all]
             [intermine-nlp.core :as core]
-            [intermine-nlp.model :as model]
-            [instaparse.core :as insta]))
+            [intermine-nlp.model :as model]))
 
 (deftest parser-pipeline-test
   (let [service {:root "www.flymine.org/query"}
         db-model (model/fetch-model service)
-        pipeline (core/parser-pipeline db-model :lemmatize true)]
+        service (assoc service :model db-model)
+        pipeline (core/parser-pipeline service)]
     (testing "Testing parser-pipeline"
-      (are [string] (insta/failure? (pipeline string))
+      (are [string] (every? empty? (vals (pipeline string)))
         "This sentence does not parse."
         "which Genes doesn't parse."
         "Gene length for all")
-      (are [string] ((complement insta/failure?) (pipeline string))
-        "show me Gene with primaryIdentifier ovo"))))
+      (are [string] (not-any? empty? (vals (pipeline string)))
+        "Show me genes with primaryIdentifier ovo"))))

--- a/test/intermine_nlp/fuzzy_test.clj
+++ b/test/intermine_nlp/fuzzy_test.clj
@@ -1,0 +1,30 @@
+(ns intermine-nlp.fuzzy-test
+  (:require [clojure.test :refer :all]
+            [intermine-nlp.model :as model]
+            [intermine-nlp.fuzzy :as fuzzy]))
+
+(def db-model (model/fetch-model "fly"))
+(def service {:root "www.flymine.org/query"
+              :model db-model})
+
+(deftest replace-class-names-test
+  (testing "Testing replace-class-names"
+    (are [string replacement]
+        (= (fuzzy/replace-class-names db-model 0.6 string) replacement)
+      "A chromosomal demo" "A Chromosome demo"
+      "Which genes have do-term foo?" "Which Gene have DOTerm foo?"
+      )
+    (are [string] (= (fuzzy/replace-class-names db-model 0.7 string) string)
+      "No classes here."
+      "Close, but no cigar")))
+
+(deftest replace-field-names-test
+  (testing "Testing replace-field-names"
+    (are [string replacement]
+        (= (fuzzy/replace-field-names db-model 0.6 string) replacement)
+      "annotatextension" "annotationExtension"
+      "Show me genes having primaryID ovo" "Show me genes having primaryIdentifier ovo")
+    (are [string] (= (fuzzy/replace-field-names db-model 0.6 string) string)
+      "No fields here."
+      "Close, but no cigar"
+      "Genetic" "Genetic")))

--- a/test/intermine_nlp/parse_test.clj
+++ b/test/intermine_nlp/parse_test.clj
@@ -6,11 +6,16 @@
             [intermine-nlp.util :as util]
             [instaparse.core :as insta]
             [imcljs.path :as im-path]
-            [clojure.test :as test]))
+            [clojure.set :refer [map-invert]]
+            [clojure.test :as test]
+            [intermine-nlp.nlp :as nlp]))
 
 (def db-model (model/fetch-model "fly"))
 (def service {:root "www.flymine.org/query"
               :model db-model})
+
+(def lemma-class-map (map-invert (parse/field-lemma-mapping db-model)))
+(def lemma-field-map (map-invert (parse/class-lemma-mapping db-model)))
 
 (def sample-text "Man request adapted spirits set pressed. Up to denoting subjects sensible feelings it indulged directly. We dwelling elegance do shutters appetite yourself diverted. Our next drew much you with rank. Tore many held age hold rose than our. She literature sentiments any contrasted. Set aware joy sense young now tears china shy.
 To shewing another demands to. Marianne property cheerful informed at striking at. Clothes parlors however by cottage on. In views it or meant drift to. Be concern parlors settled or do shyness address. Remainder northward performed out for moonlight. Yet late add name was rent park from rich. He always do do former he highly.
@@ -24,22 +29,6 @@ Put all speaking her delicate recurred possible. Set indulgence inquietude discr
 On no twenty spring of in esteem spirit likely estate. Continue new you declared differed learning bringing honoured. At mean mind so upon they rent am walk. Shortly am waiting inhabit smiling he chiefly of in. Lain tore time gone him his dear sure. Fat decisively estimating affronting assistance not. Resolve pursuit regular so calling me. West he plan girl been my then up no.")
 
 
-(deftest model-grammar-test
-  (let [model-class-parser (insta/parser (parse/model-grammar db-model) :start :CLASS)
-        model-field-parser (insta/parser (parse/model-grammar db-model) :start :FIELD)
-        class-names (->> db-model :classes vals (map :name))
-        fields (->> (map keyword class-names)
-                    (map (fn [class-kw] (randq/rand-field db-model [class-kw])))
-                    (repeat 2)
-                    distinct
-                    flatten)
-        field-names (distinct (map :name fields))]
-    (testing "Testing model-grammar"
-      (are [classes] (every? #(= (insta/parse model-class-parser %) [:CLASS %]) classes)
-        class-names)
-      (are [fields] (every? #(= (insta/parse model-field-parser %) [:FIELD %]) fields)
-        field-names))))
-
 (deftest gen-parser-test
   ;; TODO: parse collection of human-generated queries
   (let [parser1 (parse/gen-parser db-model)]
@@ -49,4 +38,4 @@ On no twenty spring of in esteem spirit likely estate. Continue new you declared
         "which Genes doesn't parse."
         "Gene length for all")
       (are [string] ((complement insta/failure?) (insta/parse parser1 string))
-        "show me Gene with primaryIdentifier ovo"))))
+        "show me gene with primaryidentifier ovo"))))

--- a/test/intermine_nlp/query_test.clj
+++ b/test/intermine_nlp/query_test.clj
@@ -1,0 +1,19 @@
+(ns intermine-nlp.query-test
+  (:require [clojure.test :refer :all]
+            [intermine-nlp.model :as model]
+            [intermine-nlp.query :as query]))
+
+(def db-model (model/fetch-model "fly"))
+(def service {:root "www.flymine.org/query"
+              :model db-model})
+
+(deftest gen-query-test
+  (let [tree1 {:VIEW [{:PATH {:CLASS "gene"}}], :CONSTRS [{:CONSTR {:PATH {:CLASS "chromosome", :FIELD "length"}, :COMPARE :LT, :VALUE "10000"}}]}
+        tree2 {:VIEW [{:PATH {:CLASS "chromosome"}}], :CONSTRS [{:CONSTR {:PATH {:FIELD "identifier"}, :VALUE "foo"}}]}
+        tree3 {:VIEW [{:PATH {:CLASS "protein"}}], :CONSTRS [{:CONSTR {:PATH {:FIELD "length"}, :COMPARE :LT, :VALUE "50000"}}]}]
+    (testing "Testing gen-query method"
+      (are [tree generated-query] (= generated-query (query/gen-query service tree))
+        tree1 {:from "Gene", :select ["Gene.secondaryIdentifier" "Gene.symbol" "Gene.primaryIdentifier" "Gene.organism.name"], :where [{:path "chromosome.length", :op "<", :value "10000"}]}
+        tree2 {:from "Chromosome", :select ["Chromosome.primaryIdentifier" "Chromosome.organism.name" "Chromosome.length"], :where [{:path "Chromosome.identifier", :op "=", :value "foo"}]}
+        tree3 {:from "Protein", :select ["Protein.primaryIdentifier" "Protein.primaryAccession" "Protein.organism.name"], :where [{:path "Protein.length", :op "<", :value "50000"}]}
+        ))))

--- a/test/intermine_nlp/query_test.clj
+++ b/test/intermine_nlp/query_test.clj
@@ -14,6 +14,6 @@
     (testing "Testing gen-query method"
       (are [tree generated-query] (= generated-query (query/gen-query service tree))
         tree1 {:from "Gene", :select ["Gene.secondaryIdentifier" "Gene.symbol" "Gene.primaryIdentifier" "Gene.organism.name"], :where [{:path "chromosome.length", :op "<", :value "10000"}]}
-        tree2 {:from "Chromosome", :select ["Chromosome.primaryIdentifier" "Chromosome.organism.name" "Chromosome.length"], :where [{:path "Chromosome.identifier", :op "=", :value "foo"}]}
+        tree2 {:from "Chromosome", :select ["Chromosome.primaryIdentifier" "Chromosome.organism.name" "Chromosome.length"], :where [{:path "Chromosome.primaryIdentifier", :op "=", :value "foo"}]}
         tree3 {:from "Protein", :select ["Protein.primaryIdentifier" "Protein.primaryAccession" "Protein.organism.name"], :where [{:path "Protein.length", :op "<", :value "50000"}]}
         ))))


### PR DESCRIPTION
I've managed to "close the loop" as far as generating legal PathQuery maps from input data. Running the default intermine-nlp pipeline on an input like "Which genes have symbols like foo" gives
```
{:from "Gene",
 :select
 ["Gene.secondaryIdentifier"
  "Gene.symbol"
  "Gene.primaryIdentifier"
  "Gene.organism.name"],
 :where [{:path "Gene.symbol", :op "LIKE", :value "foo"}]}
```

There's a ton of cool stuff going on under the hood that allowed me to get to this point, and a ton of optimizations and improvements left to explore. I've added significantly to both README documents to reflect these improvements and future plans/goals. The improvements can be summarized as fuzzy string matching, parse tree transformations, and final-stage query generation. I've added basic tests for fuzzy.clj and query.clj, not as extensive as I'd like but enough for a PR I believe.